### PR TITLE
feat: allow removing event listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,9 @@ const transmit = new Transmit({
 
 # Events
 
-The`Transmit` class uses the [`EventTarget`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget) class to emits multiple events.
+The `Transmit` class uses the [`EventTarget`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget) class to emits multiple events.
 
-  ```ts
+```ts
 transmit.on('connected', () => {
   console.log('connected')
 })
@@ -163,6 +163,17 @@ transmit.on('disconnected', () => {
 transmit.on('reconnecting', () => {
   console.log('reconnecting')
 })
+```
+
+That means you can also remove an event listener previously registered, by passing the event listener function itself.
+
+```ts
+const onConnected = () => {
+  console.log('connected')
+}
+
+transmit.on('connected', onConnected)
+transmit.off('connected', onConnected)
 ```
 
 [gh-workflow-image]: https://img.shields.io/github/actions/workflow/status/adonisjs/transmit-client/test?style=for-the-badge

--- a/src/transmit.ts
+++ b/src/transmit.ts
@@ -230,6 +230,11 @@ export class Transmit {
     this.#eventTarget?.addEventListener(event, callback)
   }
 
+  off(event: Exclude<TransmitStatus, 'connecting'>, callback: (event: CustomEvent) => void) {
+    // @ts-ignore
+    this.#eventTarget?.removeEventListener(event, callback)
+  }
+
   close() {
     this.#eventSource?.close()
   }


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

When interacting with event listeners (namely the Transmit client) inside React lifecycle, it's generally a good idea to properly cleanup them to avoid issues like multiple listeners performing the same task.

This PR makes this easier by exposing an `off` method to the Transmit client.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
